### PR TITLE
fixed bug Interference of SwipeRefreshLayout with horizontal scroll of compatCalendar.

### DIFF
--- a/app/src/main/java/com/example/calendarapp/customSwipeRefresh/CustomSwipeRefreshLayout.java
+++ b/app/src/main/java/com/example/calendarapp/customSwipeRefresh/CustomSwipeRefreshLayout.java
@@ -1,0 +1,46 @@
+package com.example.calendarapp.customSwipeRefresh;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.ViewConfiguration;
+
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
+
+public class CustomSwipeRefreshLayout extends SwipeRefreshLayout {
+
+    private int mTouchSlop;
+    private float mPrevX;
+    // Indicate if we've already declined the move event
+    private boolean mDeclined;
+
+    public CustomSwipeRefreshLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        mTouchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
+    }
+    public CustomSwipeRefreshLayout(Context context) {
+        super(context);
+        mTouchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent event) {
+
+        switch (event.getAction()) {
+            case MotionEvent.ACTION_DOWN:
+                mPrevX = MotionEvent.obtain(event).getX();
+                break;
+
+            case MotionEvent.ACTION_MOVE:
+                final float eventX = event.getX();
+                float xDiff = Math.abs(eventX - mPrevX);
+
+                if (xDiff > mTouchSlop) {
+                    return false;
+                }
+        }
+
+        return super.onInterceptTouchEvent(event);
+    }
+}

--- a/app/src/main/java/com/example/calendarapp/navigation/main/MainFragment.java
+++ b/app/src/main/java/com/example/calendarapp/navigation/main/MainFragment.java
@@ -43,6 +43,7 @@ import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
 import com.example.calendarapp.R;
 import com.example.calendarapp.adapters.AdaptorActivity;
+import com.example.calendarapp.customSwipeRefresh.CustomSwipeRefreshLayout;
 import com.example.calendarapp.data.ListItems;
 import com.example.calendarapp.database.DatabaseHandler;
 import com.github.sundeepk.compactcalendarview.CompactCalendarView;
@@ -111,7 +112,7 @@ public class MainFragment extends Fragment {
             "May", "June", "July", "August", "September", "October", "November", "December"};
 
 
-    private SwipeRefreshLayout swipeRefreshLayout;
+    private CustomSwipeRefreshLayout swipeRefreshLayout;
 
     public static MainFragment newInstance() {
         return new MainFragment();
@@ -159,6 +160,7 @@ public class MainFragment extends Fragment {
         month.setText(Selected[Integer.parseInt(dateFormat.format(date))-1]);
         //textLay.setText(sdf.format(date)+", "+dateFormat1.format(date)+" "+Selected[Integer.parseInt(dateFormat.format(date))-1]);
         compactCalendar = (CompactCalendarView) view.findViewById(R.id.compactcalendar_view);
+        compactCalendar.setNestedScrollingEnabled(false);
         compactCalendar.setUseThreeLetterAbbreviation(true);
         Log.d("date",date.toString());
 
@@ -168,11 +170,13 @@ public class MainFragment extends Fragment {
                 if(swipeRefreshLayout.isRefreshing()){
                     if(isOnline()) {
                         try {
+                            compactCalendar.removeAllEvents();
                             loadRecyclerViewData();
                         } catch (JSONException | ParseException e) {
                             e.printStackTrace();
                         } finally {
                             ResetCurrentDate();
+                            recyclerView.setVisibility(View.GONE);
                             swipeRefreshLayout.setRefreshing(false);
                         }
                     }

--- a/app/src/main/java/com/example/calendarapp/navigation/main/MainFragment.java
+++ b/app/src/main/java/com/example/calendarapp/navigation/main/MainFragment.java
@@ -171,13 +171,10 @@ public class MainFragment extends Fragment {
                     if(isOnline()) {
                         try {
                             compactCalendar.removeAllEvents();
+                            recyclerView.setVisibility(View.GONE);
                             loadRecyclerViewData();
                         } catch (JSONException | ParseException e) {
                             e.printStackTrace();
-                        } finally {
-                            ResetCurrentDate();
-                            recyclerView.setVisibility(View.GONE);
-                            swipeRefreshLayout.setRefreshing(false);
                         }
                     }
                     else{
@@ -392,8 +389,9 @@ public boolean isOnline() {
         compactCalendar.setCurrentDate(date);
         month.setText(Selected[Integer.parseInt(dateFormat.format(date))-1]);
         textLay.setText(sdf.format(date).substring(0,3)+", "+dateFormat1.format(date)+" "+Selected[Integer.parseInt(dateFormat.format(date))-1]);
-        showRecyclerView(date);
     }
+
+
 
     @RequiresApi(api = Build.VERSION_CODES.O)
     public void loadRecyclerViewData() throws JSONException, ParseException {
@@ -509,6 +507,8 @@ public boolean isOnline() {
                                         Log.d("size",String.valueOf(listItems.size()));
                                         showRecyclerView(date);
                                         databaseHandler.close();
+                                        ResetCurrentDate();
+                                        swipeRefreshLayout.setRefreshing(false);
 //                                        progressDialog.dismiss();
                                         cardView.setVisibility(View.VISIBLE);
                                         today.setVisibility(View.VISIBLE);

--- a/app/src/main/res/layout/main_fragment.xml
+++ b/app/src/main/res/layout/main_fragment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+<com.example.calendarapp.customSwipeRefresh.CustomSwipeRefreshLayout
     android:id="@+id/SwipeRefreshMain"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -166,4 +166,4 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
-</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</com.example.calendarapp.customSwipeRefresh.CustomSwipeRefreshLayout>


### PR DESCRIPTION
# What I did?
- fixed the stucking problem with the horizontal scroll of compatCalendar.
- cleared the events before refreshing and again loading the data
- fixed the issue with the visibility of recyclerview